### PR TITLE
Fix for the max_distance option

### DIFF
--- a/lib/string_metric/levenshtein/experiment.rb
+++ b/lib/string_metric/levenshtein/experiment.rb
@@ -4,10 +4,6 @@ module StringMetric
   module Levenshtein
     class Experiment
       def self.distance(from, to, options = {})
-        return 0 if from == to
-        return to.size if from.size.zero?
-        return from.size if to.size.zero?
-
         m = from.length
         n = to.length
 

--- a/lib/string_metric/levenshtein/iterative_with_full_matrix.rb
+++ b/lib/string_metric/levenshtein/iterative_with_full_matrix.rb
@@ -20,6 +20,7 @@ module StringMetric
         (1..from.size).each { |j| d[0][j] = j }
         (1..to.size).each { |i| d[i][0] = i }
 
+        to_column = 0
         (1..from.size).each do |j|
           (1..to.size).each do |i|
             if from[j-1] == to[i-1]
@@ -30,9 +31,10 @@ module StringMetric
                          d[i-1][j-1] + substitution_cost  # substitution
                         ].min
             end
+            to_column = i
           end
 
-          break if max_distance and d[j][j] > max_distance
+          break if max_distance and d[to_column].min > max_distance
         end
 
         x = d[to.size][from.size]

--- a/lib/string_metric/levenshtein/iterative_with_full_matrix.rb
+++ b/lib/string_metric/levenshtein/iterative_with_full_matrix.rb
@@ -4,25 +4,32 @@ module StringMetric
   module Levenshtein
     class IterativeWithFullMatrix
       def self.distance(from, to, options = {})
-        return 0 if from == to
-        return to.size if from.size.zero?
-        return from.size if to.size.zero?
-
         max_distance      = options[:max_distance]
         insertion_cost    = options.fetch(:insertion_cost, 1)
         deletion_cost     = options.fetch(:deletion_cost, 1)
         substitution_cost = options.fetch(:substitution_cost, 1)
 
-        d = (0..to.size).map do |i|
-          [0] * (from.size + 1)
+        m = from.length
+        n = to.length
+
+        if max_distance && (m - n).abs >= max_distance
+          return max_distance
         end
 
-        (1..from.size).each { |j| d[0][j] = j }
-        (1..to.size).each { |i| d[i][0] = i }
+        return 0 if from == to
+        return n if m.zero?
+        return m if n.zero?
+
+        d = (0..n).map do |i|
+          [0] * (m + 1)
+        end
+
+        (1..m).each { |j| d[0][j] = j }
+        (1..n).each { |i| d[i][0] = i }
 
         to_column = 0
-        (1..from.size).each do |j|
-          (1..to.size).each do |i|
+        (1..m).each do |j|
+          (1..n).each do |i|
             if from[j-1] == to[i-1]
               d[i][j] = d[i -1][j-1]
             else
@@ -37,7 +44,7 @@ module StringMetric
           break if max_distance and d[to_column].min > max_distance
         end
 
-        x = d[to.size][from.size]
+        x = d[n][m]
         if max_distance && x > max_distance
           max_distance
         else

--- a/lib/string_metric/levenshtein/iterative_with_two_matrix_rows.rb
+++ b/lib/string_metric/levenshtein/iterative_with_two_matrix_rows.rb
@@ -4,10 +4,6 @@ module StringMetric
   module Levenshtein
     class IterativeWithTwoMatrixRows
       def self.distance(from, to, options = {})
-        return 0 if from == to
-        return to.size if from.size.zero?
-        return from.size if to.size.zero?
-
         max_distance      = options[:max_distance]
         insertion_cost    = options.fetch(:insertion_cost, 1)
         deletion_cost     = options.fetch(:deletion_cost, 1)
@@ -15,6 +11,14 @@ module StringMetric
 
         m = from.length
         n = to.length
+
+        if max_distance && (n - m).abs >= max_distance
+          return max_distance
+        end
+
+        return 0 if from == to
+        return n if m.zero?
+        return m if n.zero?
 
         v0 = (0..m).to_a
         v1 = []

--- a/lib/string_metric/levenshtein/iterative_with_two_matrix_rows.rb
+++ b/lib/string_metric/levenshtein/iterative_with_two_matrix_rows.rb
@@ -41,7 +41,7 @@ module StringMetric
             sub_cell = ins_cell
           end
 
-          break if max_distance && v0[i] > max_distance
+          break if max_distance && v0.min > max_distance
 
           v0 = v1.dup
         end

--- a/lib/string_metric/levenshtein/iterative_with_two_matrix_rows_optimized.rb
+++ b/lib/string_metric/levenshtein/iterative_with_two_matrix_rows_optimized.rb
@@ -4,10 +4,6 @@ module StringMetric
   module Levenshtein
     class IterativeWithTwoMatrixRowsOptimized
       def self.distance(from, to, options = {})
-        return 0 if from == to
-        return to.size if from.size.zero?
-        return from.size if to.size.zero?
-
         max_distance      = options[:max_distance]
         insertion_cost    = options[:insertion_cost]    || 1
         deletion_cost     = options[:deletion_cost]     || 1
@@ -15,6 +11,14 @@ module StringMetric
 
         m = from.length
         n = to.length
+
+        if max_distance && (n - m).abs >= max_distance
+          return max_distance
+        end
+
+        return 0 if from == to
+        return n if m.zero?
+        return m if n.zero?
 
         from = from.codepoints.to_a
         to = to.codepoints.to_a

--- a/lib/string_metric/levenshtein/iterative_with_two_matrix_rows_optimized.rb
+++ b/lib/string_metric/levenshtein/iterative_with_two_matrix_rows_optimized.rb
@@ -43,7 +43,7 @@ module StringMetric
             sub_cell = ins_cell
           end
 
-          break if max_distance && v0[i] > max_distance
+          break if max_distance && v0.min > max_distance
 
           v0 = v1.dup
         end

--- a/lib/string_metric/levenshtein/recursive.rb
+++ b/lib/string_metric/levenshtein/recursive.rb
@@ -4,14 +4,18 @@ module StringMetric
   module Levenshtein
     class Recursive
       def self.distance(from, to, options = {})
-        return 0 if from == to
-        return to.size if from.size.zero?
-        return from.size if to.size.zero?
-
         max_distance      = options[:max_distance]
         insertion_cost    = options.fetch(:insertion_cost, 1)
         deletion_cost     = options.fetch(:deletion_cost, 1)
         substitution_cost = options.fetch(:substitution_cost, 1)
+
+        if max_distance && (from.size - to.size).abs >= max_distance
+          return max_distance
+        end
+
+        return 0 if from == to
+        return to.size if from.size.zero?
+        return from.size if to.size.zero?
 
         if from.chars.to_a.last == to.chars.to_a.last
           cost = 0

--- a/spec/fixtures/levenshtein.csv
+++ b/spec/fixtures/levenshtein.csv
@@ -6,6 +6,9 @@ hello, hellol, 1
 hello, heloll, 2
 hello, cheese, 4
 hello, saint, 5
+hellol, hello, 1
 hello,, 5
+, hello, 5
+, , 0
 sitting, kitten, 3
 αλφα, βητα, 3

--- a/spec/support/levenshtein.rb
+++ b/spec/support/levenshtein.rb
@@ -28,10 +28,12 @@ shared_examples "Levenshtein Distance" do |options|
           expect(described_class.distance("gumbo", "gambol", max_distance: 1)).to eq 1
           expect(described_class.distance("test", "tasf", max_distance: 1)).to eq 1
           expect(described_class.distance("kitten", "sitting", max_distance: 2)).to eq 2
-          expect(described_class.distance("trolol", "trololol", max_distance: 1)).to eq 1
-          expect(described_class.distance("trololol", "trolol", max_distance: 1)).to eq 1
+          expect(described_class.distance("kitten", "kittenss", max_distance: 1)).to eq 1
+          expect(described_class.distance("kittenss", "kitten", max_distance: 1)).to eq 1
           expect(described_class.distance("sitting", "kitten", max_distance: 2)).to eq 2
           expect(described_class.distance("gambol", "gumbo", max_distance: 1)).to eq 1
+          expect(described_class.distance("kitten", "", max_distance: 2)).to eq 2
+          expect(described_class.distance("", "kitten", max_distance: 3)).to eq 3
         end
       end
       context "and normal distance is less than max_distance" do
@@ -42,10 +44,13 @@ shared_examples "Levenshtein Distance" do |options|
           expect(described_class.distance("test", "tent", max_distance: 2)).to eq 1
           expect(described_class.distance("gumbo", "gambol", max_distance: 3)).to eq 2
           expect(described_class.distance("kitten", "sitting", max_distance: 4)).to eq 3
-          expect(described_class.distance("trolol", "trololol", max_distance: 4)).to eq 2
-          expect(described_class.distance("trololol", "trolol", max_distance: 4)).to eq 2
+          expect(described_class.distance("kitten", "kittenss", max_distance: 4)).to eq 2
+          expect(described_class.distance("kittenss", "kitten", max_distance: 4)).to eq 2
           expect(described_class.distance("sitting", "kitten", max_distance: 4)).to eq 3
           expect(described_class.distance("gambol", "gumbo", max_distance: 3)).to eq 2
+          expect(described_class.distance("", "cat", max_distance: 4)).to eq 3
+          expect(described_class.distance("cat", "", max_distance: 5)).to eq 3
+          expect(described_class.distance("", "", max_distance: 2)).to eq 0
         end
       end
       context "and normal distance is same as max_distance" do
@@ -54,10 +59,13 @@ shared_examples "Levenshtein Distance" do |options|
           expect(described_class.distance("test", "tent", max_distance: 1)).to eq 1
           expect(described_class.distance("gumbo", "gambol", max_distance: 2)).to eq 2
           expect(described_class.distance("kitten", "sitting", max_distance: 3)).to eq 3
-          expect(described_class.distance("trolol", "trololol", max_distance: 2)).to eq 2
-          expect(described_class.distance("trololol", "trolol", max_distance: 2)).to eq 2
+          expect(described_class.distance("kitten", "kittenss", max_distance: 2)).to eq 2
+          expect(described_class.distance("kittenss", "kitten", max_distance: 2)).to eq 2
           expect(described_class.distance("sitting", "kitten", max_distance: 3)).to eq 3
           expect(described_class.distance("gambol", "gumbo", max_distance: 2)).to eq 2
+          expect(described_class.distance("", "cat", max_distance: 3)).to eq 3
+          expect(described_class.distance("cat", "", max_distance: 3)).to eq 3
+          expect(described_class.distance("", "", max_distance: 0)).to eq 0
         end
       end
     end

--- a/spec/support/levenshtein.rb
+++ b/spec/support/levenshtein.rb
@@ -29,6 +29,9 @@ shared_examples "Levenshtein Distance" do |options|
           expect(described_class.distance("test", "tasf", max_distance: 1)).to eq 1
           expect(described_class.distance("kitten", "sitting", max_distance: 2)).to eq 2
           expect(described_class.distance("trolol", "trololol", max_distance: 1)).to eq 1
+          expect(described_class.distance("trololol", "trolol", max_distance: 1)).to eq 1
+          expect(described_class.distance("sitting", "kitten", max_distance: 2)).to eq 2
+          expect(described_class.distance("gambol", "gumbo", max_distance: 1)).to eq 1
         end
       end
       context "and normal distance is less than max_distance" do
@@ -40,6 +43,9 @@ shared_examples "Levenshtein Distance" do |options|
           expect(described_class.distance("gumbo", "gambol", max_distance: 3)).to eq 2
           expect(described_class.distance("kitten", "sitting", max_distance: 4)).to eq 3
           expect(described_class.distance("trolol", "trololol", max_distance: 4)).to eq 2
+          expect(described_class.distance("trololol", "trolol", max_distance: 4)).to eq 2
+          expect(described_class.distance("sitting", "kitten", max_distance: 4)).to eq 3
+          expect(described_class.distance("gambol", "gumbo", max_distance: 3)).to eq 2
         end
       end
       context "and normal distance is same as max_distance" do
@@ -49,6 +55,9 @@ shared_examples "Levenshtein Distance" do |options|
           expect(described_class.distance("gumbo", "gambol", max_distance: 2)).to eq 2
           expect(described_class.distance("kitten", "sitting", max_distance: 3)).to eq 3
           expect(described_class.distance("trolol", "trololol", max_distance: 2)).to eq 2
+          expect(described_class.distance("trololol", "trolol", max_distance: 2)).to eq 2
+          expect(described_class.distance("sitting", "kitten", max_distance: 3)).to eq 3
+          expect(described_class.distance("gambol", "gumbo", max_distance: 2)).to eq 2
         end
       end
     end

--- a/spec/support/levenshtein.rb
+++ b/spec/support/levenshtein.rb
@@ -24,11 +24,31 @@ shared_examples "Levenshtein Distance" do |options|
 
     context "when max_distance is passed as option" do
       context "and normal distance is greater than max_distance" do
-        let(:max_distance) { 2 }
-
         it "is trimmed to max_distance" do
-          expect(described_class.distance("kitten", "sitting",
-            max_distance: max_distance)).to eq max_distance
+          expect(described_class.distance("gumbo", "gambol", max_distance: 1)).to eq 1
+          expect(described_class.distance("test", "tasf", max_distance: 1)).to eq 1
+          expect(described_class.distance("kitten", "sitting", max_distance: 2)).to eq 2
+          expect(described_class.distance("trolol", "trololol", max_distance: 1)).to eq 1
+        end
+      end
+      context "and normal distance is less than max_distance" do
+        it "is calculated distance" do
+          expect(described_class.distance("", "t", max_distance: 2)).to eq 1
+          expect(described_class.distance("t", "", max_distance: 3)).to eq 1
+          expect(described_class.distance("test", "test", max_distance: 1)).to eq 0
+          expect(described_class.distance("test", "tent", max_distance: 2)).to eq 1
+          expect(described_class.distance("gumbo", "gambol", max_distance: 3)).to eq 2
+          expect(described_class.distance("kitten", "sitting", max_distance: 4)).to eq 3
+          expect(described_class.distance("trolol", "trololol", max_distance: 4)).to eq 2
+        end
+      end
+      context "and normal distance is same as max_distance" do
+        it "is calculated distance" do
+          expect(described_class.distance("test", "test", max_distance: 0)).to eq 0
+          expect(described_class.distance("test", "tent", max_distance: 1)).to eq 1
+          expect(described_class.distance("gumbo", "gambol", max_distance: 2)).to eq 2
+          expect(described_class.distance("kitten", "sitting", max_distance: 3)).to eq 3
+          expect(described_class.distance("trolol", "trololol", max_distance: 2)).to eq 2
         end
       end
     end


### PR DESCRIPTION
Hello,

When `max_distance` option is passed 3 things can happen:

1. Calculated distance is less than the max: return calculated distance
2. Calculated distance is more than the max: skip the rest computation and return the max distance
3. Calculated distance is equal with the max: return either value

Adding few more test cases revealed a flaw with the handling of max_distance.

The 'max_distance' check triggered a comparison with the v0 array of size 'm', 
but used 'n' as an index (where n > m).
An exception was raised for trying to compare 'max_distance' with nil
(an array out of bounds value).

Properly selecting the minimum cost calculated for the row to use in the comparison, fixes the problem.