### PR TITLE
Introduce a new variation of the Levenshtein algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.gem
 *.rbc
+*.o
+*.so
 .bundle
 .config
 .ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,3 @@ rvm:
   - "2.0.0"
   - "2.1.0"
   - "jruby-19mode"
-
-script: bundle exec rspec spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,27 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+if RUBY_ENGINE == "ruby"
+  require "rake/extensiontask"
+
+  gem_name = "string_metric"
+  dir = "#{gem_name}/levenshtein"
+  spec = Gem::Specification.load("#{gem_name}.gemspec")
+
+  Rake::ExtensionTask.new do |ext|
+    ext.name = "trie_radix_tree_ext"
+    ext.ext_dir = "ext/#{dir}"
+    ext.lib_dir = "lib/#{dir}"
+    ext.gem_spec = spec
+  end
+
+  task :default do
+    Rake::Task["compile"].invoke
+    Rake::Task["spec"].invoke
+  end
+else
+  task default: :spec
+end
+

--- a/benchmarks/dictionary.rb
+++ b/benchmarks/dictionary.rb
@@ -1,0 +1,44 @@
+require 'string_metric'
+require 'benchmark'
+require 'pp'
+
+Benchmark.bmbm(7) do |x|
+  options = {}
+  max_distance = 2
+
+  dict = []
+  trie = StringMetric::Levenshtein::TrieNode.new
+  File.open('/usr/share/dict/words', 'r').each_line do |line|
+    word = line.chomp
+    trie.insert(word)
+    dict << word
+  end
+
+  randomWords = []
+  File.open('spec/fixtures/dictionary_input.txt', 'r').each_line do |word|
+    randomWords << word.chomp
+  end
+
+  matrixResults = []
+  x.report("two_matrix_rows_v2 implementation") do
+    randomWords.each do |from|
+      dict.each do |to|
+        matrixResults << to if StringMetric::Levenshtein::IterativeWithTwoMatrixRowsOptimized.distance(from, to, options) <= max_distance
+      end
+    end
+  end
+
+  trieResults = []
+  x.report("trie_radix_tree implementation") do
+    randomWords.each do |from|
+      trieResults << StringMetric::Levenshtein::TrieRadixTree.distance(from, trie, max_distance: max_distance)
+    end
+  end
+
+  trieResultsExt = []
+  x.report("trie_radix_tree_ext implementation") do
+    randomWords.each do |from|
+      trieResultsExt << StringMetric::Levenshtein::TrieRadixTreeExt.distance(from, trie, max_distance: max_distance)
+    end
+  end
+end

--- a/ext/string_metric/levenshtein/extconf.rb
+++ b/ext/string_metric/levenshtein/extconf.rb
@@ -1,0 +1,3 @@
+require 'mkmf'
+
+create_makefile('string_metric/levenshtein/trie_radix_tree_ext')

--- a/ext/string_metric/levenshtein/trie_radix_tree_ext.c
+++ b/ext/string_metric/levenshtein/trie_radix_tree_ext.c
@@ -1,0 +1,112 @@
+#include <ruby.h>
+
+void Init_trie_radix_tree_ext(void);
+void search_recursive(VALUE node, int letter, int *current_row, VALUE results);
+VALUE search_ext(VALUE self, VALUE _from, VALUE _from_len, VALUE trie_node,
+				VALUE _max_distance, VALUE _insertion_cost,
+				VALUE _deletion_cost, VALUE _substitution_cost);
+
+#define MIN2(a, b) (((a) < (b)) ? (a) : (b))
+#define MIN3(a, b, c) (MIN2(MIN2((a), (b)), (c)))
+
+#define MALLOC_W(ptr, size) do { \
+	ptr = malloc(size);          \
+	if (!ptr)                    \
+		rb_memerror();           \
+} while (0)
+
+// Declare the variables that don't change as global, so that we don't have to pass them around
+// in our recursive function and increase the stack frame unnecessarily
+int *from, from_len;
+int max_distance, insertion_cost, deletion_cost, substitution_cost;
+
+void Init_trie_radix_tree_ext(void) {
+
+	VALUE StringMetric     = rb_define_module("StringMetric");
+	VALUE Levenshtein      = rb_define_module_under(StringMetric, "Levenshtein");
+	VALUE TrieRadixTreeExt = rb_define_class_under(Levenshtein, "TrieRadixTreeExt", rb_cObject);
+
+	rb_define_singleton_method(TrieRadixTreeExt, "trie_ext", search_ext, 7);
+}
+
+VALUE search_ext(VALUE self, VALUE _from, VALUE _from_len, VALUE trie_node,
+				VALUE _max_distance,  VALUE _insertion_cost,
+				VALUE _deletion_cost, VALUE _substitution_cost)
+{
+	int i, *current_row;
+	VALUE results, letter, node, children, children_keys;
+
+	// Convert from ruby types
+	max_distance      = FIX2INT(_max_distance);
+	insertion_cost    = FIX2INT(_insertion_cost);
+	deletion_cost     = FIX2INT(_deletion_cost);
+	substitution_cost = FIX2INT(_substitution_cost);
+	from_len          = FIX2INT(_from_len);
+
+	// The '_from' word is passed as an array of codepoints. Allocate memory and populate the C array
+	MALLOC_W(from, from_len * sizeof(int));
+	for (i = 0; i < from_len; i++)
+		from[i] = FIX2INT(rb_ary_entry(_from, i));
+
+	// Create a hash to store the results and return it to ruby when we are done
+	results = rb_hash_new();
+
+	MALLOC_W(current_row, (from_len + 1) * sizeof(int));
+	for (i = 0; i <= from_len; i++)
+		current_row[i] = i;
+
+	// Extract the hash from trie_node object and get an array of keys
+	children = rb_funcall(trie_node, rb_intern("children"), 0);
+	children_keys = rb_funcall(children, rb_intern("keys"), 0);
+
+	for (i = 0; i < RARRAY_LEN(children_keys); i++) {
+		letter = rb_ary_entry(children_keys, i);
+		node = rb_hash_aref(children, letter);
+		search_recursive(node, FIX2INT(letter), current_row, results);
+	}
+	free(from);
+	free(current_row);
+	return results;
+}
+
+void search_recursive(VALUE node, int letter, int *previous_row, VALUE results) {
+
+	int i, min, columns, distance, *current_row;
+	int cost, insert_cost, delete_cost, replace_cost;
+	VALUE word, codepoint, children, children_keys;
+
+	columns = from_len + 1;
+	MALLOC_W(current_row, columns * sizeof(int));
+	current_row[0] = previous_row[0] + 1;
+
+	for (i = 1; i < columns; i++) {
+		cost = (from[i - 1] == letter) ? 0 : substitution_cost;
+		insert_cost  = current_row[i - 1]  + insertion_cost;
+		delete_cost  = previous_row[i]     + deletion_cost;
+		replace_cost = previous_row[i - 1] + cost;
+
+		current_row[i] = MIN3(insert_cost, delete_cost, replace_cost);
+	}
+	distance = current_row[columns - 1];
+	word = rb_funcall(node, rb_intern("word"), 0);
+
+	if (distance <= max_distance && word != Qnil)
+		rb_hash_aset(results, word, INT2FIX(distance));
+
+	min = current_row[0];
+	for (i = 1; i < columns; i++)
+		if (current_row[i] < min)
+			min = current_row[i];
+
+	if (min <= max_distance) {
+		children = rb_funcall(node, rb_intern("children"), 0);
+		children_keys = rb_funcall(children, rb_intern("keys"), 0);
+
+		for (i = 0; i < RARRAY_LEN(children_keys); i++) {
+			codepoint = rb_ary_entry(children_keys, i);
+			node = rb_hash_aref(children, codepoint);
+			search_recursive(node, FIX2INT(codepoint), current_row, results);
+		}
+	}
+	free(current_row);
+}

--- a/lib/string_metric/levenshtein.rb
+++ b/lib/string_metric/levenshtein.rb
@@ -5,6 +5,9 @@ require_relative "levenshtein/iterative_with_two_matrix_rows"
 require_relative "levenshtein/iterative_with_two_matrix_rows_optimized"
 require_relative "levenshtein/iterative_with_full_matrix"
 require_relative "levenshtein/recursive"
+require_relative "levenshtein/trie_node"
+require_relative "levenshtein/trie_radix_tree"
+require_relative "levenshtein/trie_radix_tree_ext"
 
 module StringMetric
   # Levenshtein Distance implementation

--- a/lib/string_metric/levenshtein/trie_node.rb
+++ b/lib/string_metric/levenshtein/trie_node.rb
@@ -1,0 +1,23 @@
+# coding: utf-8
+
+module StringMetric
+  module Levenshtein
+    class TrieNode
+      attr_accessor :word, :children
+
+      def initialize
+        @word = nil
+        @children = {}
+      end
+
+      def insert(word)
+        node = self
+        word.codepoints.each do |char|
+          node.children[char] = TrieNode.new unless node.children.key?(char)
+          node = node.children[char]
+        end
+        node.word = word
+      end
+    end
+  end
+end

--- a/lib/string_metric/levenshtein/trie_radix_tree.rb
+++ b/lib/string_metric/levenshtein/trie_radix_tree.rb
@@ -1,0 +1,49 @@
+# coding: utf-8
+
+module StringMetric
+  module Levenshtein
+    class TrieRadixTree
+      def self.distance(from, node, options = {})
+
+        @max_distance      = options[:max_distance]      || 0
+        @insertion_cost    = options[:insertion_cost]    || 1
+        @deletion_cost     = options[:deletion_cost]     || 1
+        @substitution_cost = options[:substitution_cost] || 1
+
+        results = []
+        word = from.codepoints
+        currentRow = (0..word.length).to_a
+
+        node.children.keys.each do |letter|
+          searchRecursive(node.children[letter], letter, word, currentRow, results)
+        end
+
+        results
+      end
+
+      def self.searchRecursive(node, letter, word, previousRow, results)
+        columns = word.length + 1
+        currentRow = [previousRow[0] + 1]
+
+        (1...columns).each do |column|
+          insertCost = currentRow[column - 1] + @insertion_cost
+          deleteCost = previousRow[column] + @deletion_cost
+          cost = (word[column - 1] == letter) ? 0 : @substitution_cost
+          replaceCost = previousRow[column - 1] + cost
+
+          currentRow << [insertCost, deleteCost, replaceCost].min
+        end
+
+        if currentRow.last <= @max_distance && !node.word.nil?
+          results << [node.word, currentRow.last]
+        end
+
+        if currentRow.min <= @max_distance
+          node.children.keys.each do |letter|
+            searchRecursive(node.children[letter], letter, word, currentRow, results)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/string_metric/levenshtein/trie_radix_tree_ext.rb
+++ b/lib/string_metric/levenshtein/trie_radix_tree_ext.rb
@@ -1,0 +1,20 @@
+# coding: utf-8
+
+require_relative 'trie_radix_tree_ext.so'
+
+module StringMetric
+  module Levenshtein
+    class TrieRadixTreeExt
+      def self.distance(from, trieNode, options = {})
+
+        max_distance      = options[:max_distance]      || 0
+        insertion_cost    = options[:insertion_cost]    || 1
+        deletion_cost     = options[:deletion_cost]     || 1
+        substitution_cost = options[:substitution_cost] || 1
+
+        trie_ext(from.codepoints, from.length, trieNode, max_distance,
+                 insertion_cost, deletion_cost, substitution_cost)
+      end
+    end
+  end
+end

--- a/spec/fixtures/dictionary_input.txt
+++ b/spec/fixtures/dictionary_input.txt
@@ -1,0 +1,10 @@
+aliency
+prostatauxe
+Herbartian
+womanize
+unviolent
+disguised
+preanimism
+birdling
+geognosy
+daut

--- a/string_metric.gemspec
+++ b/string_metric.gemspec
@@ -24,6 +24,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "text", "~> 1.2.3"
 
   if RUBY_ENGINE == "ruby"
+    spec.add_development_dependency "rake-compiler", "~> 0.9.2"
+    spec.extensions << "ext/#{spec.name}/levenshtein/extconf.rb"
+
     if RUBY_VERSION > "1.9.3"
       spec.add_development_dependency "pry-byebug", "~> 1.2.1"
     else


### PR DESCRIPTION
#### Introduction

Disclaimer: the interface for this implementation is not compatible with the one this gem enforces, so it might not be a good candidate for merging. Nevertheless, it's a very good representation of what can be achieved using a more efficient approach.

Trie (or radix / prefix tree) is a data structure with performance characteristics that can even beat those of a hash. (search misses for example don't have to examine the whole key, therefore completing in sub-linear time)
When traversing a trie we can find all keys / words with the same prefix. We can exploit this property to feed the Levenshtein algorithm with all the words that contain the same prefix, in order.
We only to have to calculate the difference between the previous smaller prefix word instead of doing the whole computation again.

For more info: http://stevehanov.ca/blog/index.php?id=114

#### Using the algorithm

This is where the interface differs from the rest implementations. Instead of 2 words to match, the method expects 1 word and a prebuilt Trie data structure. `distance(from, TrieNode, options = {})`
Building the Trie tree is a matter of simply inserting the words we want to match against (e.x. dictionary) in any order we have them.
Assuming we already have the words in the `dictionary` array, the building of the Trie will look similar to this:

    trie = StringMetric::Levenshtein::TrieNode.new
    dictionary.each do |word| 
      trie.insert(word)
    end

This implementation is very good when we want to quickly get a list of all the words that have a set maximum_distance compared to ours. e.x.: `StringMetric::Levenshtein::TrieRadixTree.distance('case', products, max_distance: 1)`

It should also be very fast when we watch to match on longer sequence of words since, if we reach a word that exceeds our max_distance, all the rest nodes starting with that same prefix are discarded.

#### Benchmark results

So how much faster is this strategy versus randomly feeding words to Levenshtein?
Here are some results using 10 words and matching them with a dictionary of `234937` words on my system's `/usr/share/dict/words` file.

Implementation                                      | User      | Real
------------------------------------------------- |-----------------|-----------
two_matrix_rows_v2 implementation     | 108.520000 | (108.629240)
two_matrix_rows_ext implementation    | 6.170000     | (  6.165258)
trie_radix_tree implementation              | 1.570000     | (  1.574100)
trie_radix_tree_ext implementation       | 0.080000     | (  0.077781)

#### Downsides

First there is the disparity in the interface. A different set of tests is required, although i personally tested it against the reference python implementation and the one from the `text` gem.

Second, there is a time and space cost associated with populating the Trie data structure.
On my machine the time cost, far outweighed the actual computation of the algorithm. ~1.8 secs to generate the tree, 0.07 sec to run the benchmark.

If one could afford even less flexibility, the populating step could be done inside the native extension written in C.
The problem with that is the big space requirements of the data structure. Each node must hold an array of size as big as the biggest codepoint of the required character set (e.x. 256 for the extended ascii set)
For the dictionary mentioned above we have 234937 words in 791098 nodes.
791098 nodes * 256 array_bytes = 202521088 bytes = ~200mb ram

And indeed the program occupies around 220mb ram while holding the data structure.
The real problem comes when you have to support unicode. Assuming unicode requires ~ 65000 codepoints the above calculation becomes:
791098 nodes * 65000 array_bytes = 51421370000 bytes = ~50**gb** ram

Ruby gets around that by using hashes instead of arrays, so it does not have to keep the whole codeset in each node.

I ventured even further and implemented a [ternary search tree](http://en.wikipedia.org/wiki/Ternary_search_tree) which is a more compact version of tries.
Each node holds 3 other nodes instead of the whole array.
I was able to get the memory usage down to ~160mb but the populating running time cost increased by a lot due to the added complexity.
That was in ruby, in C it would be faster of course.
